### PR TITLE
Updating inventory in hatch task to get pokemon name for hatched eggs

### DIFF
--- a/src/main/java/dekk/pw/pokemate/tasks/HatchEgg.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/HatchEgg.java
@@ -19,6 +19,8 @@ class HatchEgg extends Task {
     public void run() {
         try {
             List<HatchedEgg> eggs = context.getApi().getInventories().getHatchery().queryHatchedEggs();
+            //try another inventory update to ensure hatched pokemon are added to bank
+            context.getApi().getInventories().updateInventories(true);
             eggs.forEach(egg -> {
                 Pokemon hatchedPokemon = context.getApi().getInventories().getPokebank().getPokemonById(egg.getId());
                 String details = String.format("candy: %s  exp: %s  stardust: %s", egg.getCandy(), egg.getExperience(), egg.getStardust());


### PR DESCRIPTION
performing another inventory update to force pokemon added to pokebank fast enough to get name. this could be moved into the for-each loop so it is only called when eggs are returned too.
