### PR TITLE
Fix unchanged key in config reader

### DIFF
--- a/src/main/java/dekk/pw/pokemate/Config.java
+++ b/src/main/java/dekk/pw/pokemate/Config.java
@@ -56,7 +56,7 @@ public class Config {
             preferredBall = ItemIdOuterClass.ItemId.valueOf(properties.getProperty("preferred_ball", "ITEM_POKE_BALL")).getNumber();
             eggsIncubating = Boolean.parseBoolean(properties.getProperty("eggs_incubating", "true"));
             eggsHatching = Boolean.parseBoolean(properties.getProperty("eggs_hatching", "true"));
-            transferPrefersIV = Boolean.parseBoolean(properties.getProperty("transfer-prefers-iv", "false"));
+            transferPrefersIV = Boolean.parseBoolean(properties.getProperty("transfer_prefers_iv", "false"));
             //whitelist
             String whiteList = properties.getProperty("whitelisted_pokemon", null);
             whiteListedPokemon = new ArrayList<>();


### PR DESCRIPTION
All but transfer-prefers-iv was changed to have underscores instead of hyphens. The config property template was changed however this code was not.
