### PR TITLE
Added always_transfer_pokemon and log refactoring

### DIFF
--- a/config.properties.template
+++ b/config.properties.template
@@ -27,7 +27,7 @@ automatic_evolving=true
 range=.004
 #points in the map path
 map_points=15
-# Only whitelist certain pokemons
+# Only evolve certain pokemons. If auto-evolve is on, only these pokemon are evolved
 whitelisted_pokemon=10,13,16
 # List of Pokémons ids to NEVER transfer, separated by commas.
 never_transfer=
@@ -47,3 +47,5 @@ drop_item_list=ITEM_POTION,ITEM_SUPER_POTION,ITEM_MAX_POTION,ITEM_HYPER_POTION,I
 minimum_cp_for_ui_message=0
 # Prefer IV over CP when transfering? true keeps highest IV, false keeps highest CP
 transfer_prefers_iv=false
+# Always transfer the pokemon, regardless of CP, IV%, or any setting above. Based upon the transfer_prefers_iv settings, and therefore the best IV% or CP one is kept.
+always_transfer_pokemon=

--- a/src/main/java/dekk/pw/pokemate/Config.java
+++ b/src/main/java/dekk/pw/pokemate/Config.java
@@ -39,6 +39,8 @@ public class Config {
     private static boolean transferPrefersIV;
 	private static int cpMinimumForMessage;
     private static Properties properties = new Properties();
+	private static List<Integer> alwaysTransferPokemon;
+	private static String alwaysTransferPokemonText;
 
     public static void load(String configPath) {
         try {
@@ -78,6 +80,11 @@ public class Config {
 			fillListString(droppedItemNames, droppedItems);
 			// minimum cp for message
 			cpMinimumForMessage = Integer.parseInt(properties.getProperty("minimum_cp_for_ui_message", "0"));
+			// always transfer pokemon
+			alwaysTransferPokemon = new ArrayList<>();
+			alwaysTransferPokemonText = properties.getProperty("always_transfer_pokemon", null);
+			fillList(alwaysTransferPokemonText, alwaysTransferPokemon);
+			
         } catch (IOException e) {
             e.printStackTrace();
             JOptionPane.showMessageDialog(null, e.getMessage());
@@ -217,4 +224,8 @@ public class Config {
     public static void setTransferPrefersIV(boolean transferPrefersIV) {
         Config.transferPrefersIV = transferPrefersIV;
     }
+	
+	public static List<Integer> getAlwaysTransferPokemon() {
+		return alwaysTransferPokemon;
+	}
 }

--- a/src/main/java/dekk/pw/pokemate/PokeMateUI.java
+++ b/src/main/java/dekk/pw/pokemate/PokeMateUI.java
@@ -88,6 +88,9 @@ public class PokeMateUI extends Application implements MapComponentInitializedLi
 
     public static void addMessageToLog(String message) {
         messagesForLog += "[" + new SimpleDateFormat("HH:mm:ss").format(new Date()) + "] - " + message + "\\r\\n\\r\\n";
+		if (Config.isConsoleNotification()) {
+			System.out.println("[" + new SimpleDateFormat("HH:mm:ss").format(new Date()) + "] - " + message);
+		}
     }
 
     private static String millisToTimeString(long millis) {

--- a/src/main/java/dekk/pw/pokemate/tasks/CatchPokemon.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/CatchPokemon.java
@@ -68,16 +68,13 @@ public class CatchPokemon extends Task {
                                     if (p.getCp() > Config.getMinimumCPForMessage()) {
                                         PokeMateUI.toast(output, Config.POKE + "mon caught!", "icons/" + target.getPokemonId().getNumber() + ".png");
                                     } else {
-										output += "(IV: " + getIvRatio(p) + "%)";
-                                        System.out.println("[" + new SimpleDateFormat("HH:mm:ss").format(new Date()) + "] - " + output);
-                                        PokeMateUI.addMessageToLog(output);
+                                        PokeMateUI.addMessageToLog(output + " (IV: " + getIvRatio(p) + "%)");
                                     }
                                 }
                             } catch (NullPointerException | IndexOutOfBoundsException ex) {
                                 ex.printStackTrace();
                             }
                         } else {
-                            System.out.println("[" + new SimpleDateFormat("HH:mm:ss").format(new Date()) + "] - " + target.getPokemonId() + " fled.");
                             PokeMateUI.addMessageToLog(target.getPokemonId() + " fled.");
                         }
                     }

--- a/src/main/java/dekk/pw/pokemate/tasks/ReleasePokemon.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/ReleasePokemon.java
@@ -32,15 +32,16 @@ public class ReleasePokemon extends Task {
             } else {
                 Collections.sort(list, (a, b) -> a.getCp() - b.getCp());
             }
-            list.stream().filter(p -> p.getCp() < Config.getMinCP() && list.indexOf(p) < list.size() - 1 && !p.isFavorite() && context.getIvRatio(p) < Config.getIvRatio() && !Config.getNeverTransferPokemon().contains(p.getPokemonId().getNumber())).forEach(p -> {
-                //Passing this filter means they are not a 'perfect pokemon'
-                try {
-                    p.transferPokemon();
-					PokeMateUI.addMessageToLog("Transferring " + (list.indexOf(p) + 1) + "/" + list.size() + " " + p.getPokemonId() + " CP " + p.getCp() + " [" + p.getIndividualAttack() + "/" + p.getIndividualDefense() + "/" + p.getIndividualStamina() + "]");
-                } catch (LoginFailedException | RemoteServerException e) {
-                    e.printStackTrace();
-                }
-
+            list.stream()
+				.filter(p -> ((p.getCp() < Config.getMinCP() && list.indexOf(p) < list.size() - 1 && !p.isFavorite() && context.getIvRatio(p) < Config.getIvRatio() && !Config.getNeverTransferPokemon().contains(p.getPokemonId().getNumber())) || (Config.getAlwaysTransferPokemon().contains(p.getPokemonId().getNumber()) && list.indexOf(p) < list.size() - 1)))
+				.forEach(p -> {
+					//Passing this filter means they are not a 'perfect pokemon' or on the list to always be transferred
+					try {
+						p.transferPokemon();
+						PokeMateUI.addMessageToLog("Transferring " + (list.indexOf(p) + 1) + "/" + list.size() + " " + p.getPokemonId() + " CP " + p.getCp() + " [" + p.getIndividualAttack() + "/" + p.getIndividualDefense() + "/" + p.getIndividualStamina() + "]");
+					} catch (LoginFailedException | RemoteServerException e) {
+						e.printStackTrace();
+					}
             });
         }
     }


### PR DESCRIPTION
Logging redundancy in certain areas reduced.

Fixed config template to better explain what whitelisting was (should stop people asking all the time)

Added always_transfer_pokemon, this will always transfer that type of pokemon and there will never be more than 1 in the inventory, and that 1 will be the best CP or IV% available based upon transfer priority property.
