### PR TITLE
README - Fix border on "Sign in with Slack" logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can download the release from the Releases tab, only requirement is Java 8. 
 ![Image of map](http://i.imgur.com/pCVLX6y.png)
 
 ##Slack
-Come join us on slack! [![Slack](http://i.imgur.com/XwQF3RR.png)](https://frozen-sea-68189.herokuapp.com/)
+Come join us on slack! [![Slack](http://i.imgur.com/XeDYkVL.png)](https://frozen-sea-68189.herokuapp.com/)
 
 ### Credits
 


### PR DESCRIPTION
Re-uploaded a slack logo to fix the border that was cut off.
