### PR TITLE
Asyncronous Tasks and Mutex Lock Implementation

### DIFF
--- a/src/main/java/dekk/pw/pokemate/Config.java
+++ b/src/main/java/dekk/pw/pokemate/Config.java
@@ -43,6 +43,7 @@ public class Config {
 	private static int cpMinimumForMessage;
     private static Navigate.NavigationType navigationType;
     private static Properties properties = new Properties();
+    private static int minItemAmount;
 
     public static void load(String configPath) {
         try {
@@ -88,6 +89,8 @@ public class Config {
 			// minimum cp for message
 			cpMinimumForMessage = Integer.parseInt(properties.getProperty("minimum_cp_for_ui_message", "0"));
             navigationType = Navigate.NavigationType.valueOf(properties.getProperty("navigation_type","STREETS"));
+            minItemAmount = Integer.parseInt(properties.getProperty("minimum_item_amount", "0"));
+
         } catch (IOException e) {
             e.printStackTrace();
             JOptionPane.showMessageDialog(null, e.getMessage());
@@ -231,5 +234,9 @@ public class Config {
 
     public static void setTransferPrefersIV(boolean transferPrefersIV) {
         Config.transferPrefersIV = transferPrefersIV;
+    }
+
+    public static int getMinItemAmount() {
+        return minItemAmount;
     }
 }

--- a/src/main/java/dekk/pw/pokemate/Context.java
+++ b/src/main/java/dekk/pw/pokemate/Context.java
@@ -7,6 +7,8 @@ import com.pokegoapi.api.pokemon.Pokemon;
 import com.pokegoapi.auth.*;
 
 import com.pokegoapi.util.SystemTimeImpl;
+import com.sun.corba.se.impl.orbutil.concurrent.Mutex;
+import dekk.pw.pokemate.util.Time;
 import okhttp3.OkHttpClient;
 
 import javax.swing.*;
@@ -34,7 +36,9 @@ public class Context {
     private AtomicBoolean walking = new AtomicBoolean(false);
     private CredentialProvider credentialProvider;
     private static SystemTimeImpl time = new SystemTimeImpl();
-
+    private int MinimumAPIWaitTime = 4000;
+    public Mutex APILock = new Mutex();
+    private boolean runStatus;
 
     public Context(PokemonGo go, PlayerProfile profile, boolean walking, CredentialProvider credentialProvider, OkHttpClient http) {
         this.api = go;
@@ -42,7 +46,7 @@ public class Context {
         this.walking.set(walking);
         this.credentialProvider = credentialProvider;
         this.http = http;
-
+        this.runStatus = true;
     }
 
     public static CredentialProvider Login(OkHttpClient httpClient) {
@@ -127,9 +131,9 @@ public class Context {
         this.http = http;
     }
 
-    public PokemonGo getApi() {
-        return api;
-    }
+    public PokemonGo getApi() { return api; }
+
+    public int getMinimumAPIWaitTime() { return MinimumAPIWaitTime; }
 
     public void setApi(PokemonGo api) {
         this.api = api;
@@ -150,6 +154,8 @@ public class Context {
     public AtomicBoolean getWalking() {
         return walking;
     }
+
+    public boolean getRunStatus() { return runStatus; }
 
     public CredentialProvider getCredentialProvider() {
         return credentialProvider;

--- a/src/main/java/dekk/pw/pokemate/Context.java
+++ b/src/main/java/dekk/pw/pokemate/Context.java
@@ -8,7 +8,6 @@ import com.pokegoapi.auth.*;
 
 import com.pokegoapi.util.SystemTimeImpl;
 import com.sun.corba.se.impl.orbutil.concurrent.Mutex;
-import dekk.pw.pokemate.util.Time;
 import okhttp3.OkHttpClient;
 
 import javax.swing.*;

--- a/src/main/java/dekk/pw/pokemate/PokeMateUI.java
+++ b/src/main/java/dekk/pw/pokemate/PokeMateUI.java
@@ -39,7 +39,7 @@ import java.util.List;
  */
 public class PokeMateUI extends Application implements MapComponentInitializedListener {
 
-    public static final int UPDATE_TIME = 5000;
+    public static final int UPDATE_TIME = 1000;
     public static final double XVARIANCE = Config.getRange() * 1.5;
     public static final double VARIANCE = Config.getRange();
     private static final String NOTIFY = "$.notify({\n" +
@@ -201,7 +201,7 @@ public class PokeMateUI extends Application implements MapComponentInitializedLi
                         Navigate.getRoute().forEach(a -> locs.add(new LatLong(a.latDegrees(), a.lngDegrees())));
 
                         LatLong[] array = locs.toArray(new LatLong[0]);
-                        System.out.println(array.length);
+
                         MVCArray mvc = new MVCArray(array);
 
                         PolylineOptions polyOpts = new PolylineOptions()

--- a/src/main/java/dekk/pw/pokemate/Walking.java
+++ b/src/main/java/dekk/pw/pokemate/Walking.java
@@ -4,7 +4,6 @@ import com.google.common.geometry.S2LatLng;
 import com.google.common.util.concurrent.AtomicDouble;
 import com.google.maps.model.DirectionsStep;
 import com.pokegoapi.util.Log;
-import dekk.pw.pokemate.util.Time;
 
 import java.util.Timer;
 import java.util.TimerTask;

--- a/src/main/java/dekk/pw/pokemate/Walking.java
+++ b/src/main/java/dekk/pw/pokemate/Walking.java
@@ -4,10 +4,11 @@ import com.google.common.geometry.S2LatLng;
 import com.google.common.util.concurrent.AtomicDouble;
 import com.google.maps.model.DirectionsStep;
 import com.pokegoapi.util.Log;
+import dekk.pw.pokemate.util.Time;
 
 import java.util.Timer;
 import java.util.TimerTask;
-
+import java.util.*;
 /**
  * Created by TimD on 7/21/2016.
  */
@@ -29,9 +30,7 @@ public class Walking {
         }
     }
 
-    public static void walk( final Context context, S2LatLng end) {
-        if (context.isWalking())
-            return;
+    public static void walk( final Context context, S2LatLng end) { // PokeStop Walking
         context.getWalking().set(true);
         S2LatLng start = S2LatLng.fromDegrees(context.getLat().get(), context.getLng().get());
         S2LatLng diff = end.sub(start);
@@ -41,60 +40,61 @@ public class Walking {
         final AtomicDouble stepsRequired = new AtomicDouble(timeRequired / (timeout / 1000D));
         double deltaLat = diff.latDegrees() / stepsRequired.get();
         double deltaLng = diff.lngDegrees() / stepsRequired.get();
+
         //Schedule a timer to walk every 200 ms
+
+
         new Timer().scheduleAtFixedRate(new TimerTask() {
             @Override
             public void run() {
                 context.getApi().setLocation(context.getLat().addAndGet(deltaLat), context.getLng().addAndGet(deltaLng), 0);
                 stepsRequired.getAndAdd(-1);
                 if (stepsRequired.get() <= 0) {
-                    System.out.println("Destination reached.");
                     context.getWalking().set(false);
                     cancel();
                 }
-                //   System.out.println(context.getLat().get() + " " + context.getLng().get() + " " + stepsRequired);
+                //System.out.println(context.getLat().get() + " " + context.getLng().get() + " " + stepsRequired);
             }
         }, 0, timeout);
     }
 
-    public static void walk(Context context, DirectionsStep[] steps) {
-        new Thread(() -> {
-            context.getWalking().set(true);
-            if (steps != null) {
-                for (DirectionsStep step : steps) {
-                    //Log.i("WALKER", "Heading to: [" + step.endLocation.lat + ", " + step.endLocation.lng + "]");
-                    context.getApi().setLocation(step.startLocation.lat, step.startLocation.lng, 0);
-                    context.getLat().set(step.startLocation.lat);
-                    context.getLng().set(step.startLocation.lng);
-                    S2LatLng start = S2LatLng.fromDegrees(step.startLocation.lat, step.startLocation.lng);
-                    S2LatLng end = S2LatLng.fromDegrees(step.endLocation.lat, step.endLocation.lng);
-                    S2LatLng diff = end.sub(start);
-                    double distance = step.distance.inMeters;
-                    distance = start.getEarthDistance(end);
-                    long timeout = 350L;
-                    double timeRequired = distance / Config.getSpeed();
-                    int stepsRequired = (int) (timeRequired / (new Long(timeout).doubleValue() / 1000));
-                    double deltaLat = diff.latDegrees() / stepsRequired;
-                    double deltaLng = diff.lngDegrees() / stepsRequired;
-                    int remainingSteps = stepsRequired;
-                    while (remainingSteps >= 0) {
-                        context.getLat().addAndGet(deltaLat);
-                        context.getLng().addAndGet(deltaLng);
-                        setLocation(context);
-                        try {
-                            Thread.sleep(timeout);
-                        } catch (InterruptedException e) {
-                            e.printStackTrace();
-                        }
-                         //  Log.i("WALKER", "Set location: [" + context.getLat().get() + ", " + context.getLng().get() + "]");
-                        remainingSteps--;
+    public static void walk(Context context, DirectionsStep[] steps) {  // Streets Walking
+        context.getWalking().set(true);
+        if (steps != null) {
+            for (DirectionsStep step : steps) {
+                //Log.i("WALKER", "Heading to: [" + step.endLocation.lat + ", " + step.endLocation.lng + "]");
+                context.getApi().setLocation(step.startLocation.lat, step.startLocation.lng, 0);
+                context.getLat().set(step.startLocation.lat);
+                context.getLng().set(step.startLocation.lng);
+                S2LatLng start = S2LatLng.fromDegrees(step.startLocation.lat, step.startLocation.lng);
+                S2LatLng end = S2LatLng.fromDegrees(step.endLocation.lat, step.endLocation.lng);
+                S2LatLng diff = end.sub(start);
+                double distance = step.distance.inMeters;
+                distance = start.getEarthDistance(end);
+                long timeout = 350L;
+                double timeRequired = distance / Config.getSpeed();
+                int stepsRequired = (int) (timeRequired / (new Long(timeout).doubleValue() / 1000));
+                double deltaLat = diff.latDegrees() / stepsRequired;
+                double deltaLng = diff.lngDegrees() / stepsRequired;
+                int remainingSteps = stepsRequired;
+                while (remainingSteps >= 0) {
+                    context.getLat().addAndGet(deltaLat);
+                    context.getLng().addAndGet(deltaLng);
+                    setLocation(context);
+                    try {
+                        Thread.sleep(timeout);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
                     }
-                    //Log.i("WALKER", "Arrived at: [" + step.endLocation.lat + ", " + step.endLocation.lng + "]");
+                     //  Log.i("WALKER", "Set location: [" + context.getLat().get() + ", " + context.getLng().get() + "]");
+                    remainingSteps--;
                 }
-            }else{
-                System.out.println("WALKING ERROR");
+                //Log.i("WALKER", "Arrived at: [" + step.endLocation.lat + ", " + step.endLocation.lng + "]");
             }
-            context.getWalking().set(false);
-        }).start();
+        }else{
+            System.out.println("WALKING ERROR");
+        }
+        context.getWalking().set(false);
+
     }
 }

--- a/src/main/java/dekk/pw/pokemate/tasks/CatchPokemon.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/CatchPokemon.java
@@ -15,7 +15,6 @@ import dekk.pw.pokemate.Context;
 import dekk.pw.pokemate.PokeMateUI;
 import dekk.pw.pokemate.Walking;
 import dekk.pw.pokemate.util.StringConverter;
-import dekk.pw.pokemate.util.Time;
 
 import java.text.SimpleDateFormat;
 import java.util.*;

--- a/src/main/java/dekk/pw/pokemate/tasks/CatchPokemon.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/CatchPokemon.java
@@ -21,6 +21,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static POGOProtos.Networking.Responses.CatchPokemonResponseOuterClass.CatchPokemonResponse.CatchStatus.CATCH_SUCCESS;
+import static dekk.pw.pokemate.util.Time.sleep;
 
 /**
  * Created by TimD on 7/21/2016.
@@ -33,51 +34,61 @@ public class CatchPokemon extends Task {
 
     @Override
     public void run() {
-        try {
-            Pokeball pokeball = null;
-            List<CatchablePokemon> pokemon = context.getApi().getMap().getCatchablePokemon().stream()
+        while(context.getRunStatus()) {
+            System.out.println("[CatchPokemon] Active");
+            try {
+                Pokeball pokeball = null;
+                context.APILock.attempt(1000);
+                APIStartTime = System.currentTimeMillis();
+                List<CatchablePokemon> pokemon = context.getApi().getMap().getCatchablePokemon().stream()
                     .filter(this::shouldIgnore)
                     .collect(Collectors.toList());
 
-            if (pokemon.size() == 0) {
-                return;
-            }
+                APIElapsedTime = System.currentTimeMillis() - APIStartTime;
+                if (APIElapsedTime < context.getMinimumAPIWaitTime()) {
+                    sleep(context.getMinimumAPIWaitTime() - APIElapsedTime);
+                }
+                context.APILock.release();
 
-            Item ball = itemBag().getItem(getItemForId(Config.getPreferredBall()));
-            if (ball != null && ball.getCount() > 0) {
-                pokeball = getBallForId(Config.getPreferredBall());
-            } else {
-                //find any pokeball we can.
-                for (Pokeball pb : Pokeball.values()) {
-                    ball = itemBag().getItem(pb.getBallType());
-                    if (ball != null && ball.getCount() > 0) {
-                        pokeball = pb;
-                        break;
+                if (pokemon.size() == 0) {
+                    continue;
+                }
+
+                Item ball = itemBag().getItem(getItemForId(Config.getPreferredBall()));
+                if (ball != null && ball.getCount() > 0) {
+                    pokeball = getBallForId(Config.getPreferredBall());
+                } else {
+                    //find any pokeball we can.
+                    for (Pokeball pb : Pokeball.values()) {
+                        ball = itemBag().getItem(pb.getBallType());
+                        if (ball != null && ball.getCount() > 0) {
+                            pokeball = pb;
+                            continue;
+                        }
                     }
                 }
-            }
 
-            CatchablePokemon target = pokemon.get(0);
-            if (target == null || pokeball == null) {
-                return;
-            }
+                CatchablePokemon target = pokemon.get(0);
+                if (target == null || pokeball == null) {
+                    continue;
+                }
 
-            Walking.setLocation(context);
-            EncounterResult encounterResult = target.encounterPokemon();
-            if (!encounterResult.wasSuccessful()) {
-                return;
-            }
+                Walking.setLocation(context);
+                EncounterResult encounterResult = target.encounterPokemon();
+                if (!encounterResult.wasSuccessful()) {
+                    continue;
+                }
 
-            CatchResult catchResult = target.catchPokemon(pokeball);
-            if (catchResult.getStatus() != CATCH_SUCCESS) {
-                log(target.getPokemonId() + " fled.");
-                return;
-            }
+                CatchResult catchResult = target.catchPokemon(pokeball);
+                if (catchResult.getStatus() != CATCH_SUCCESS) {
+                    log(target.getPokemonId() + " fled.");
+                    continue;
+                }
 
-            try {
-                final String targetId = target.getPokemonId().name();
+                try {
+                    final String targetId = target.getPokemonId().name();
 
-                pokemons().stream()
+                    pokemons().stream()
                         .filter(pkmn -> pkmn.getPokemonId().name().equals(targetId))
                         .sorted((a, b) -> Long.compare(b.getCreationTimeMs(), a.getCreationTimeMs()))
                         .findFirst()
@@ -90,11 +101,18 @@ public class CatchPokemon extends Task {
                                 log(output + " [IV: " + getIvRatio(p) + "%]");
                             }
                         });
-            } catch (NullPointerException ex) {
-                ex.printStackTrace();
+                } catch (NullPointerException ex) {
+                    ex.printStackTrace();
+                }
+            } catch (LoginFailedException | RemoteServerException e) {
+                //e.printStackTrace();
+                System.out.println("[CatchPokemon] Hit Rate Limited");
+                Time.sleepRate();
+            } catch (InterruptedException e) {
+                System.out.println("[CatchPokemon] Error - TImed out waiting for API");
+                // e.printStackTrace();
             }
-        } catch (LoginFailedException | RemoteServerException e) {
-            e.printStackTrace();
+            System.out.println("[CatchPokemon] Loop Ended");
         }
     }
 

--- a/src/main/java/dekk/pw/pokemate/tasks/CatchPokemon.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/CatchPokemon.java
@@ -15,6 +15,7 @@ import dekk.pw.pokemate.Context;
 import dekk.pw.pokemate.PokeMateUI;
 import dekk.pw.pokemate.Walking;
 import dekk.pw.pokemate.util.StringConverter;
+import dekk.pw.pokemate.util.Time;
 
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -26,7 +27,7 @@ import static dekk.pw.pokemate.util.Time.sleep;
 /**
  * Created by TimD on 7/21/2016.
  */
-public class CatchPokemon extends Task {
+public class CatchPokemon extends Task  implements Runnable {
 
     CatchPokemon(final Context context) {
         super(context);
@@ -35,7 +36,7 @@ public class CatchPokemon extends Task {
     @Override
     public void run() {
         while(context.getRunStatus()) {
-            System.out.println("[CatchPokemon] Active");
+            //System.out.println("[CatchPokemon] Active");
             try {
                 Pokeball pokeball = null;
                 context.APILock.attempt(1000);
@@ -107,12 +108,10 @@ public class CatchPokemon extends Task {
             } catch (LoginFailedException | RemoteServerException e) {
                 //e.printStackTrace();
                 System.out.println("[CatchPokemon] Hit Rate Limited");
-                Time.sleepRate();
             } catch (InterruptedException e) {
                 System.out.println("[CatchPokemon] Error - TImed out waiting for API");
                 // e.printStackTrace();
             }
-            System.out.println("[CatchPokemon] Loop Ended");
         }
     }
 

--- a/src/main/java/dekk/pw/pokemate/tasks/DropItems.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/DropItems.java
@@ -24,6 +24,7 @@ public class DropItems extends Task implements Runnable {
     @Override
     public void run() {
         while(context.getRunStatus()) {
+            System.out.println("DropItems Started");
             Config.getDroppedItems().stream().forEach(itemToDrop -> {
                 ItemId id = ItemId.valueOf(itemToDrop);
                 try {
@@ -39,7 +40,6 @@ public class DropItems extends Task implements Runnable {
                     if (count > Config.getMinItemAmount()) {
                         context.APILock.attempt(1000);
                         APIStartTime = System.currentTimeMillis();
-                        context.getApi().getInventories().getItemBag().removeItem(id, count);
                         context.getApi().getInventories().getItemBag().removeItem(id, count - Config.getMinItemAmount());
                         APIElapsedTime = System.currentTimeMillis() - APIStartTime;
                         if (APIElapsedTime < context.getMinimumAPIWaitTime()) {

--- a/src/main/java/dekk/pw/pokemate/tasks/DropItems.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/DropItems.java
@@ -35,20 +35,18 @@ public class DropItems extends Task implements Runnable {
                     if (APIElapsedTime < context.getMinimumAPIWaitTime()) {
                         sleep(context.getMinimumAPIWaitTime() - APIElapsedTime);
                     }
-                    context.APILock.release();
 
                     if (count > Config.getMinItemAmount()) {
-                        context.APILock.attempt(1000);
                         APIStartTime = System.currentTimeMillis();
                         context.getApi().getInventories().getItemBag().removeItem(id, count - Config.getMinItemAmount());
                         APIElapsedTime = System.currentTimeMillis() - APIStartTime;
                         if (APIElapsedTime < context.getMinimumAPIWaitTime()) {
                             sleep(context.getMinimumAPIWaitTime() - APIElapsedTime);
                         }
-                        context.APILock.release();
 
                         String removedItem = "Removed " + StringConverter.titleCase(id.name()) + "(x" + count + ")";
                         PokeMateUI.toast(removedItem, "Items removed!", "icons/items/" + id.getNumber() + ".png");
+                        context.APILock.release();
                     }
                 } catch (RemoteServerException | LoginFailedException e) {
                     System.out.println("[DropItems] Hit Rate Limited");

--- a/src/main/java/dekk/pw/pokemate/tasks/DropItems.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/DropItems.java
@@ -40,6 +40,7 @@ public class DropItems extends Task implements Runnable {
                         context.APILock.attempt(1000);
                         APIStartTime = System.currentTimeMillis();
                         context.getApi().getInventories().getItemBag().removeItem(id, count);
+                        context.getApi().getInventories().getItemBag().removeItem(id, count - Config.getMinItemAmount());
                         APIElapsedTime = System.currentTimeMillis() - APIStartTime;
                         if (APIElapsedTime < context.getMinimumAPIWaitTime()) {
                             sleep(context.getMinimumAPIWaitTime() - APIElapsedTime);

--- a/src/main/java/dekk/pw/pokemate/tasks/DropItems.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/DropItems.java
@@ -15,7 +15,7 @@ import static dekk.pw.pokemate.util.Time.sleep;
 /**
  * Created by TimD on 7/22/2016.
  */
-public class DropItems extends Task {
+public class DropItems extends Task implements Runnable {
 
     DropItems(final Context context) {
         super(context);
@@ -36,7 +36,7 @@ public class DropItems extends Task {
                     }
                     context.APILock.release();
 
-                    if (count > 0) {
+                    if (count > Config.getMinItemAmount()) {
                         context.APILock.attempt(1000);
                         APIStartTime = System.currentTimeMillis();
                         context.getApi().getInventories().getItemBag().removeItem(id, count);

--- a/src/main/java/dekk/pw/pokemate/tasks/DropItems.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/DropItems.java
@@ -25,16 +25,13 @@ public class DropItems extends Task implements Runnable {
     public void run() {
         while(context.getRunStatus()) {
             System.out.println("DropItems Started");
+
             Config.getDroppedItems().stream().forEach(itemToDrop -> {
                 ItemId id = ItemId.valueOf(itemToDrop);
                 try {
                     context.APILock.attempt(1000);
                     APIStartTime = System.currentTimeMillis();
                     int count = context.getApi().getInventories().getItemBag().getItem(id).getCount();
-                    APIElapsedTime = System.currentTimeMillis() - APIStartTime;
-                    if (APIElapsedTime < context.getMinimumAPIWaitTime()) {
-                        sleep(context.getMinimumAPIWaitTime() - APIElapsedTime);
-                    }
 
                     if (count > Config.getMinItemAmount()) {
                         APIStartTime = System.currentTimeMillis();
@@ -43,7 +40,6 @@ public class DropItems extends Task implements Runnable {
                         if (APIElapsedTime < context.getMinimumAPIWaitTime()) {
                             sleep(context.getMinimumAPIWaitTime() - APIElapsedTime);
                         }
-
                         String removedItem = "Removed " + StringConverter.titleCase(id.name()) + "(x" + count + ")";
                         PokeMateUI.toast(removedItem, "Items removed!", "icons/items/" + id.getNumber() + ".png");
                         context.APILock.release();

--- a/src/main/java/dekk/pw/pokemate/tasks/EvolvePokemon.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/EvolvePokemon.java
@@ -20,7 +20,7 @@ import static dekk.pw.pokemate.util.Time.sleep;
 /**
  * Created by TimD on 7/22/2016.
  */
-public class EvolvePokemon extends Task {
+public class EvolvePokemon extends Task implements Runnable {
     private static final ConcurrentHashMap<Integer, Integer> CANDY_AMOUNTS = new ConcurrentHashMap<>();
 
     static {
@@ -43,7 +43,7 @@ public class EvolvePokemon extends Task {
 
     @Override
     public void run() {
-        System.out.println("[Evolve] Activating..");
+        //System.out.println("[Evolve] Activating..");
         while(context.getRunStatus()) {
             try {
                 context.APILock.attempt(1000);

--- a/src/main/java/dekk/pw/pokemate/tasks/EvolvePokemon.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/EvolvePokemon.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.ListIterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import static dekk.pw.pokemate.util.Time.sleep;
 
 /**
  * Created by TimD on 7/22/2016.
@@ -42,25 +43,39 @@ public class EvolvePokemon extends Task {
 
     @Override
     public void run() {
-        try {
-            CopyOnWriteArrayList<Pokemon> pokeList = new CopyOnWriteArrayList<>(context.getApi().getInventories().getPokebank().getPokemons());
-            for (Pokemon pokemon : pokeList)
-                if (!Config.isWhitelistEnabled() || Config.getWhitelistedPokemon().contains(pokemon.getPokemonId().getNumber())) {
-                    int number = pokemon.getPokemonId().getNumber();
-                    if (CANDY_AMOUNTS.containsKey(number)) {
-                        int required = CANDY_AMOUNTS.get(number);
-                        if (required < 1) continue;
-                        if (pokemon.getCandy() >= required) {
-                            EvolutionResult result = pokemon.evolve();
-                            if (result!=null && result.isSuccessful()) {
-                                String evolutionresult = StringConverter.titleCase(pokemon.getPokemonId().name()) + " has evolved into " + StringConverter.titleCase(result.getEvolvedPokemon().getPokemonId().name()) + " costing " + required + " candies";
-                                PokeMateUI.toast(evolutionresult, Config.POKE + "mon evolved!", "icons/" + pokemon.getPokemonId().getNumber() + ".png");
+        System.out.println("[Evolve] Activating..");
+        while(context.getRunStatus()) {
+            try {
+                context.APILock.attempt(1000);
+                APIStartTime = System.currentTimeMillis();
+                CopyOnWriteArrayList<Pokemon> pokeList = new CopyOnWriteArrayList<>(context.getApi().getInventories().getPokebank().getPokemons());
+                APIElapsedTime = System.currentTimeMillis() - APIStartTime;
+                if (APIElapsedTime < context.getMinimumAPIWaitTime()) {
+                    sleep(context.getMinimumAPIWaitTime() - APIElapsedTime);
+                }
+                context.APILock.release();
+                for (Pokemon pokemon : pokeList)
+                    if (!Config.isWhitelistEnabled() || Config.getWhitelistedPokemon().contains(pokemon.getPokemonId().getNumber())) {
+                        int number = pokemon.getPokemonId().getNumber();
+                        if (CANDY_AMOUNTS.containsKey(number)) {
+                            int required = CANDY_AMOUNTS.get(number);
+                            if (required < 1) continue;
+                            if (pokemon.getCandy() >= required) {
+                                EvolutionResult result = pokemon.evolve();
+                                if (result != null && result.isSuccessful()) {
+                                    String evolutionresult = StringConverter.titleCase(pokemon.getPokemonId().name()) + " has evolved into " + StringConverter.titleCase(result.getEvolvedPokemon().getPokemonId().name()) + " costing " + required + " candies";
+                                    PokeMateUI.toast(evolutionresult, Config.POKE + "mon evolved!", "icons/" + pokemon.getPokemonId().getNumber() + ".png");
+                                }
                             }
                         }
                     }
-                }
-        } catch (RemoteServerException | LoginFailedException e1) {
-            e1.printStackTrace();
+            } catch (RemoteServerException | LoginFailedException e1) {
+                System.out.println("[EvolvePokemon] Hit Rate Limited");
+                e1.printStackTrace();
+            } catch (InterruptedException e) {
+                System.out.println("[] Error - Timed out waiting for API");
+                // e.printStackTrace();
+            }
         }
     }
 }

--- a/src/main/java/dekk/pw/pokemate/tasks/HatchEgg.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/HatchEgg.java
@@ -12,7 +12,7 @@ import javafx.scene.image.Image;
 import java.util.List;
 import static dekk.pw.pokemate.util.Time.sleep;
 
-class HatchEgg extends Task {
+class HatchEgg extends Task  implements Runnable{
     HatchEgg(final Context context) {
         super(context);
     }

--- a/src/main/java/dekk/pw/pokemate/tasks/IncubateEgg.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/IncubateEgg.java
@@ -16,7 +16,7 @@ import static dekk.pw.pokemate.util.Time.sleep;
 /**
  * Created by $ Tim Dekker on 7/23/2016.
  */
-public class IncubateEgg extends Task {
+public class IncubateEgg extends Task implements Runnable {
 
     IncubateEgg(final Context context) {
         super(context);

--- a/src/main/java/dekk/pw/pokemate/tasks/IncubateEgg.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/IncubateEgg.java
@@ -11,6 +11,7 @@ import javafx.scene.image.Image;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import static dekk.pw.pokemate.util.Time.sleep;
 
 /**
  * Created by $ Tim Dekker on 7/23/2016.
@@ -23,18 +24,31 @@ public class IncubateEgg extends Task {
 
     @Override
     public void run() {
-        try {
-            List<EggIncubator> incubators = context.getApi().getInventories().getIncubators().stream().filter(i -> !i.isInUse()).collect(Collectors.toList());
-            List<EggPokemon> eggs = context.getApi().getInventories().getHatchery().getEggs().stream().filter(egg -> egg.getEggIncubatorId() == null || egg.getEggIncubatorId().isEmpty()).collect(Collectors.toList());
-            if (incubators.size() > 0 && eggs.size() > 0) {
-                UseItemEggIncubatorResponseOuterClass.UseItemEggIncubatorResponse.Result result = incubators.get(0).hatchEgg(eggs.get(0));
-                if (result.equals(UseItemEggIncubatorResponseOuterClass.UseItemEggIncubatorResponse.Result.SUCCESS)) {
-                    String eggresult = "Now incubating egg ( " + eggs.get(0).getEggKmWalkedTarget()+"km)";
-                    PokeMateUI.toast(eggresult,"Egg Incubated!","icons/items/egg.png");
+        while(context.getRunStatus()) {
+            try {
+                context.APILock.attempt(1000);
+                APIStartTime = System.currentTimeMillis();
+                List<EggIncubator> incubators = context.getApi().getInventories().getIncubators().stream().filter(i -> !i.isInUse()).collect(Collectors.toList());
+                APIElapsedTime = System.currentTimeMillis() - APIStartTime;
+                if (APIElapsedTime < context.getMinimumAPIWaitTime()) {
+                    sleep(context.getMinimumAPIWaitTime() - APIElapsedTime);
                 }
+                context.APILock.release();
+
+                List<EggPokemon> eggs = context.getApi().getInventories().getHatchery().getEggs().stream().filter(egg -> egg.getEggIncubatorId() == null || egg.getEggIncubatorId().isEmpty()).collect(Collectors.toList());
+                if (incubators.size() > 0 && eggs.size() > 0) {
+                    UseItemEggIncubatorResponseOuterClass.UseItemEggIncubatorResponse.Result result = incubators.get(0).hatchEgg(eggs.get(0));
+                    if (result.equals(UseItemEggIncubatorResponseOuterClass.UseItemEggIncubatorResponse.Result.SUCCESS)) {
+                        String eggresult = "Now incubating egg ( " + eggs.get(0).getEggKmWalkedTarget() + "km)";
+                        PokeMateUI.toast(eggresult, "Egg Incubated!", "icons/items/egg.png");
+                    }
+                }
+            } catch (LoginFailedException | RemoteServerException e) {
+                e.printStackTrace();
+            } catch (InterruptedException e) {
+                System.out.println("[] Error - Timed out waiting for API");
+                // e.printStackTrace();
             }
-        } catch (LoginFailedException | RemoteServerException e) {
-            e.printStackTrace();
         }
     }
 }

--- a/src/main/java/dekk/pw/pokemate/tasks/Navigate.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/Navigate.java
@@ -6,13 +6,17 @@ import com.google.maps.DirectionsApiRequest;
 import com.google.maps.GeoApiContext;
 import com.google.maps.model.*;
 import com.pokegoapi.api.map.fort.Pokestop;
+import com.pokegoapi.exceptions.LoginFailedException;
+import com.pokegoapi.exceptions.RemoteServerException;
 import dekk.pw.pokemate.Config;
 import dekk.pw.pokemate.Context;
 import dekk.pw.pokemate.Walking;
-
+import dekk.pw.pokemate.util.Time;
 import java.util.*;
+import java.util.concurrent.Semaphore;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
+
+import static dekk.pw.pokemate.util.Time.sleep;
 
 
 /**
@@ -28,6 +32,7 @@ public class Navigate extends Task {
     private int routesIndex = 0;
     private static final Object lock = new Object();
     static NavigationType navigationType = Config.getNavigationType();
+
 
     public Navigate(final Context context, LatLng min, LatLng max) {
         super(context);
@@ -63,13 +68,19 @@ public class Navigate extends Task {
      */
     private void populateRoute(Context context) {
         try {
+
+            context.APILock.attempt(1000);
+            APIStartTime = System.currentTimeMillis();
             List<Pokestop> stops = context.getApi().getMap().getMapObjects().getPokestops().stream().filter(a ->
                     //only pokestops in our region
                     a.getLatitude() >= min.lat &&
                             a.getLatitude() <= max.lat &&
                             a.getLongitude() >= min.lng &&
                             a.getLongitude() <= max.lng).collect(Collectors.toList());
-            long count = stops.size();
+            APIElapsedTime = System.currentTimeMillis() - APIStartTime;
+            if ( APIElapsedTime < context.getMinimumAPIWaitTime()) { sleep(context.getMinimumAPIWaitTime()-APIElapsedTime); }
+            context.APILock.release();
+            int count = stops.size();
             last = S2LatLng.fromDegrees(context.getApi().getLatitude(), context.getApi().getLongitude());
             while (route.size() < count - 1) {
                 List<Pokestop> tempStops = stops.stream().filter(a -> !ids.contains(a.getId())).sorted((a, b) -> {
@@ -89,29 +100,38 @@ public class Navigate extends Task {
                 ids.add(first.getId());
             }
             route.add(S2LatLng.fromDegrees(context.getLat().get(), context.getLng().get()));
-        } catch (Exception e) {
-            e.printStackTrace();
+        } catch (RemoteServerException e) {
+            System.out.println("[Navigate] Error - Hit Rate limiter.");
+            //e.printStackTrace();
+        } catch (LoginFailedException e) {
+            System.out.println("[Navigate] Login Failed.");
+            //e.printStackTrace();
+        } catch (InterruptedException e) {
+            System.out.println("[Navigate] Error - TImed out waiting for API");
+                //e.printStackTrace();
         }
     }
 
     @Override
     public void run() {
-        if (context.isWalking()) {
-            return;
-        } else if (navigationType.equals(NavigationType.STREETS) && routesIndex >= getDirections().size()) {
-            routesIndex = 0;
-        } else if (navigationType.equals(NavigationType.POKESTOPS) && routesIndex >= route.size()) {
-            routesIndex = 0;
-        }
-        switch (navigationType) {
-            case POKESTOPS:
-                Walking.walk(context, route.get(routesIndex++));
-                return;
-            case POKEMON:
-                //TODO: walk dynamically to nearest pokemon
-                return;
-            default:
-                Walking.walk(context, getDirections().get(routesIndex++));
+        while(context.getRunStatus()) {
+            if (context.isWalking()) {
+                continue;
+            } else if (navigationType.equals(NavigationType.STREETS) && routesIndex >= getDirections().size()) {
+                routesIndex = 0;
+            } else if (navigationType.equals(NavigationType.POKESTOPS) && routesIndex >= route.size()) {
+                routesIndex = 0;
+            }
+            switch (navigationType) {
+                case POKESTOPS:
+                    Walking.walk(context, route.get(routesIndex++));
+                    break;
+                case POKEMON:
+                    //TODO: walk dynamically to nearest pokemon
+                    break;
+                default:
+                    Walking.walk(context, getDirections().get(routesIndex++));
+            }
         }
     }
 

--- a/src/main/java/dekk/pw/pokemate/tasks/Navigate.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/Navigate.java
@@ -23,7 +23,7 @@ import static dekk.pw.pokemate.util.Time.sleep;
  * Created by TimD on 7/21/2016.
  * Credit: https://github.com/mjmfighter/pokemon-go-bot/blob/master/src/main/java/com/mjmfighter/pogobot/LocationWalker.java
  */
-public class Navigate extends Task {
+public class Navigate extends Task implements Runnable {
 
     private final LatLng min, max;
     private static List<DirectionsStep[]> routes = new ArrayList<>();

--- a/src/main/java/dekk/pw/pokemate/tasks/Navigate.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/Navigate.java
@@ -11,9 +11,7 @@ import com.pokegoapi.exceptions.RemoteServerException;
 import dekk.pw.pokemate.Config;
 import dekk.pw.pokemate.Context;
 import dekk.pw.pokemate.Walking;
-import dekk.pw.pokemate.util.Time;
 import java.util.*;
-import java.util.concurrent.Semaphore;
 import java.util.stream.Collectors;
 
 import static dekk.pw.pokemate.util.Time.sleep;

--- a/src/main/java/dekk/pw/pokemate/tasks/ReleasePokemon.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/ReleasePokemon.java
@@ -8,13 +8,15 @@ import dekk.pw.pokemate.Config;
 import dekk.pw.pokemate.Context;
 import dekk.pw.pokemate.PokeMateUI;
 import dekk.pw.pokemate.util.Time;
-
+import dekk.pw.pokemate.util.Time;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.Date;
 import java.text.SimpleDateFormat;
+
+import static dekk.pw.pokemate.util.Time.sleep;
 
 /**
  * Created by TimD on 7/21/2016.
@@ -27,28 +29,43 @@ public class ReleasePokemon extends Task {
 
     @Override
     public void run() {
-        Map<PokemonIdOuterClass.PokemonId, List<Pokemon>> groups = context.getApi().getInventories().getPokebank().getPokemons().stream().collect(Collectors.groupingBy(Pokemon::getPokemonId));
-        for (List<Pokemon> list : groups.values()) {
-            if (Config.isTransferPrefersIV()) {
-                Collections.sort(list, (a, b) -> context.getIvRatio(a) - context.getIvRatio(b));
-            } else {
-                Collections.sort(list, (a, b) -> a.getCp() - b.getCp());
-            }
-            int minCP = Config.getMinCP();
-            list.stream().filter(p -> (minCP <= 1 || p.getCp() < minCP) &&
-                    list.indexOf(p) < list.size() - 1 &&
-                    context.getIvRatio(p) < Config.getIvRatio() &&
-                    !Config.getNeverTransferPokemon().contains(p.getPokemonId().getNumber())).forEach(p -> {
-                //Passing this filter means they are not a 'perfect pokemon'
-                try {
-                    p.transferPokemon();
-                    Time.sleepRate();
-                    PokeMateUI.addMessageToLog("Transferring " + (list.indexOf(p) + 1) + "/" + list.size() + " " + p.getPokemonId() + " CP " + p.getCp() + " [" + p.getIndividualAttack() + "/" + p.getIndividualDefense() + "/" + p.getIndividualStamina() + "]");
-                } catch (LoginFailedException | RemoteServerException e) {
-                    e.printStackTrace();
+        while(context.getRunStatus()) {
+            try {
+                context.APILock.attempt(1000);
+                APIStartTime = System.currentTimeMillis();
+                Map<PokemonIdOuterClass.PokemonId, List<Pokemon>> groups = context.getApi().getInventories().getPokebank().getPokemons().stream().collect(Collectors.groupingBy(Pokemon::getPokemonId));
+                APIElapsedTime = System.currentTimeMillis() - APIStartTime;
+                if (APIElapsedTime < context.getMinimumAPIWaitTime()) {
+                    sleep(context.getMinimumAPIWaitTime() - APIElapsedTime);
                 }
+                context.APILock.release();
 
-            });
+                for (List<Pokemon> list : groups.values()) {
+                    if (Config.isTransferPrefersIV()) {
+                        Collections.sort(list, (a, b) -> context.getIvRatio(a) - context.getIvRatio(b));
+                    } else {
+                        Collections.sort(list, (a, b) -> a.getCp() - b.getCp());
+                    }
+                    int minCP = Config.getMinCP();
+                    list.stream().filter(p -> (minCP <= 1 || p.getCp() < minCP) &&
+                        list.indexOf(p) < list.size() - 1 &&
+                        context.getIvRatio(p) < Config.getIvRatio() &&
+                        !Config.getNeverTransferPokemon().contains(p.getPokemonId().getNumber())).forEach(p -> {
+                        //Passing this filter means they are not a 'perfect pokemon'
+                        try {
+                            p.transferPokemon();
+                            Time.sleepRate();
+                            PokeMateUI.addMessageToLog("Transferring " + (list.indexOf(p) + 1) + "/" + list.size() + " " + p.getPokemonId() + " CP " + p.getCp() + " [" + p.getIndividualAttack() + "/" + p.getIndividualDefense() + "/" + p.getIndividualStamina() + "]");
+                        } catch (LoginFailedException | RemoteServerException e) {
+                            e.printStackTrace();
+                        }
+
+                    });
+                }
+            } catch (InterruptedException e) {
+                System.out.println("[] Error - TImed out waiting for API");
+                // e.printStackTrace();
+            }
         }
     }
 

--- a/src/main/java/dekk/pw/pokemate/tasks/TagPokestop.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/TagPokestop.java
@@ -18,7 +18,7 @@ import static dekk.pw.pokemate.util.Time.sleep;
 /**
  * Created by TimD on 7/21/2016.
  */
-public class TagPokestop extends Task {
+public class TagPokestop extends Task implements Runnable {
 
     TagPokestop(final Context context) {
         super(context);
@@ -47,7 +47,14 @@ public class TagPokestop extends Task {
                     .forEach(near -> {
                         Walking.setLocation(context);
                         try {
+                            context.APILock.attempt(1000);
+                            APIStartTime = System.currentTimeMillis();
                             String result = resultMessage(near.loot());
+                            APIElapsedTime = System.currentTimeMillis() - APIStartTime;
+                            if (APIElapsedTime < context.getMinimumAPIWaitTime()) {
+                                sleep(context.getMinimumAPIWaitTime() - APIElapsedTime);
+                            }
+                            context.APILock.release();
                             PokeMateUI.toast(result, Config.POKE + "Stop interaction!", "icons/pokestop.png");
                         } catch (LoginFailedException | RemoteServerException e) {
                             System.out.println("[Tag Pokestop] Hit Rate Limited");

--- a/src/main/java/dekk/pw/pokemate/tasks/TagPokestop.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/TagPokestop.java
@@ -13,6 +13,7 @@ import dekk.pw.pokemate.Walking;
 import java.util.ArrayList;
 
 import static dekk.pw.pokemate.util.StringConverter.convertItemAwards;
+import static dekk.pw.pokemate.util.Time.sleep;
 
 /**
  * Created by TimD on 7/21/2016.
@@ -25,14 +26,23 @@ public class TagPokestop extends Task {
 
     @Override
     public void run() {
-        try {
-            MapObjects map = context.getApi().getMap().getMapObjects();
-            ArrayList<Pokestop> pokestops = new ArrayList<>(map.getPokestops());
-            if (pokestops.size() == 0) {
-                return;
-            }
+        while(context.getRunStatus()) {
+            try {
+                context.APILock.attempt(1000);
+                APIStartTime = System.currentTimeMillis();
+                MapObjects map = context.getApi().getMap().getMapObjects();
+                APIElapsedTime = System.currentTimeMillis() - APIStartTime;
+                if (APIElapsedTime < context.getMinimumAPIWaitTime()) {
+                    sleep(context.getMinimumAPIWaitTime() - APIElapsedTime);
+                }
+                context.APILock.release();
 
-            pokestops.stream()
+                ArrayList<Pokestop> pokestops = new ArrayList<>(map.getPokestops());
+                if (pokestops.size() == 0) {
+                    return;
+                }
+
+                pokestops.stream()
                     .filter(Pokestop::canLoot)
                     .forEach(near -> {
                         Walking.setLocation(context);
@@ -40,11 +50,20 @@ public class TagPokestop extends Task {
                             String result = resultMessage(near.loot());
                             PokeMateUI.toast(result, Config.POKE + "Stop interaction!", "icons/pokestop.png");
                         } catch (LoginFailedException | RemoteServerException e) {
+                            System.out.println("[Tag Pokestop] Hit Rate Limited");
+                            e.printStackTrace();
+                        } catch (InterruptedException e) {
+                            System.out.println("[Tag Pokestop] Error - Timed out waiting for API");
                             e.printStackTrace();
                         }
                     });
-        } catch (LoginFailedException | RemoteServerException e) {
-            e.printStackTrace();
+            } catch (LoginFailedException | RemoteServerException e) {
+                System.out.println("[Tag PokeStop] Hit Rate Limited");
+                e.printStackTrace();
+            } catch (InterruptedException e) {
+                System.out.println("[Tag PokeStop] Error - Timed out waiting for API");
+                // e.printStackTrace();
+            }
         }
     }
 

--- a/src/main/java/dekk/pw/pokemate/tasks/Task.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/Task.java
@@ -7,6 +7,9 @@ import dekk.pw.pokemate.Context;
  */
 public abstract class Task {
 
+    protected static long APIStartTime;
+    protected static long APIElapsedTime;
+
     protected final Context context;
 
     Task(final Context context) {

--- a/src/main/java/dekk/pw/pokemate/tasks/TaskController.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/TaskController.java
@@ -5,7 +5,8 @@ import dekk.pw.pokemate.Context;
 import dekk.pw.pokemate.Config;
 
 import java.util.ArrayList;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * Created by TimD on 7/21/2016.
@@ -17,43 +18,30 @@ public class TaskController extends Thread {
 
     public TaskController(final Context context) {
         this.context = context;
-        tasks.add(new Navigate(context, new LatLng(context.getLat().get() - VARIANCE, context.getLng().get() - VARIANCE),
-                new LatLng(context.getLat().get() + VARIANCE, context.getLng().get() + VARIANCE)));
-
-        tasks.add(new Update(context));
-        tasks.add(new CatchPokemon(context));
-
-        if (Config.isAutoEvolving()) {
-            tasks.add(new EvolvePokemon(context));
-        }
-
-        tasks.add(new ReleasePokemon(context));
-        tasks.add(new TagPokestop(context));
-
-        if(Config.isEggsIncubating()) {
-            tasks.add(new IncubateEgg(context));
-        }
-
-        if(Config.isEggsHatching()) {
-            tasks.add(new HatchEgg(context));
-        }
-
-        if (Config.isDropItems()) {
-            tasks.add(new DropItems(context));
-        }
     }
 
     /**
      * This will execute all Tasks, then proceed to wait up to 5 seconds has passed.
      */
     public void run() {
-        try {
-            while (true) {
-                tasks.forEach(Task::run);
-                TimeUnit.SECONDS.sleep(5);
-            }
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+        ExecutorService executor = Executors.newFixedThreadPool(6);
+
+
+        executor.submit(new Navigate(context,
+            new LatLng(context.getLat().get() - VARIANCE, context.getLng().get() - VARIANCE),
+            new LatLng(context.getLat().get() + VARIANCE, context.getLng().get() + VARIANCE)));
+
+
+        executor.submit(new Update(context));
+        executor.submit(new CatchPokemon(context));
+        executor.submit(new ReleasePokemon(context));
+        executor.submit(new TagPokestop(context));
+
+        if (Config.isAutoEvolving()) executor.submit(new EvolvePokemon(context));
+        if (Config.isEggsIncubating()) executor.submit(new IncubateEgg(context));
+        if (Config.isEggsHatching()) executor.submit(new HatchEgg(context));
+        if (Config.isDropItems()) executor.submit(new DropItems(context));
+
     }
 }
+

--- a/src/main/java/dekk/pw/pokemate/tasks/TaskController.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/TaskController.java
@@ -24,7 +24,7 @@ public class TaskController extends Thread {
      * This will execute all Tasks, then proceed to wait up to 5 seconds has passed.
      */
     public void run() {
-        ExecutorService executor = Executors.newFixedThreadPool(6);
+        ExecutorService executor = Executors.newFixedThreadPool(9);
 
 
         executor.submit(new Navigate(context,

--- a/src/main/java/dekk/pw/pokemate/tasks/Update.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/Update.java
@@ -5,12 +5,13 @@ import com.pokegoapi.api.player.PlayerProfile;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import dekk.pw.pokemate.Context;
-import dekk.pw.pokemate.PokeMate;
 import dekk.pw.pokemate.PokeMateUI;
 
 import java.text.DecimalFormat;
 
+
 import static dekk.pw.pokemate.util.StringConverter.convertItemAwards;
+import static dekk.pw.pokemate.util.Time.sleep;
 
 /**
  * Created by TimD on 7/22/2016.
@@ -27,42 +28,63 @@ public class Update extends Task {
 	private static double xpHr;
     private static DecimalFormat ratioFormat = new DecimalFormat("#0.00");
 
+
     Update(final Context context) {
         super(context);
     }
 
     @Override
     public void run() {
-        try {
-            PlayerProfile player;
-            context.setProfile(player = context.getApi().getPlayerProfile());
-            player.updateProfile();
-            context.getApi().getInventories().updateInventories(true);
-//            long nextXP = REQUIRED_EXPERIENCES[player.getStats().getLevel()] - REQUIRED_EXPERIENCES[player.getStats().getLevel() - 1];
-            long curTotalXP = player.getStats().getExperience();
-            if (curTotalXP > lastExperience) {
-                if (lastExperience != 0) {
-                    experienceGained += curTotalXP - lastExperience;
+        while (context.getRunStatus()) {
+            try {
+                PlayerProfile player;
+                context.APILock.attempt(1000);
+                APIStartTime = System.currentTimeMillis();
+                context.setProfile(player = context.getApi().getPlayerProfile());
+                APIElapsedTime = System.currentTimeMillis() - APIStartTime;
+                if (APIElapsedTime < context.getMinimumAPIWaitTime()) {
+                    sleep(context.getMinimumAPIWaitTime() - APIElapsedTime);
                 }
-                lastExperience = curTotalXP;
-            }
-            long runTime = System.currentTimeMillis() - PokeMate.startTime;
-			xpHr = (experienceGained / (runTime / 3.6E6));
+                context.APILock.release();
+                player.updateProfile();
 
-            int curLevel = player.getStats().getLevel();
-            if (curLevel > lastLevel) {
-                PlayerLevelUpRewards rewards = player.acceptLevelUpRewards(curLevel - 1);
-                if (rewards.getStatus() == PlayerLevelUpRewards.Status.NEW) {
-                    String levelUp = "New level: " + curLevel;
-                    levelUp += convertItemAwards(rewards.getRewards());
-                    PokeMateUI.toast(levelUp, "Level Up", "icons/items/backpack.png");
+                context.APILock.attempt(1000);
+                APIStartTime = System.currentTimeMillis();
+                context.getApi().getInventories().updateInventories(true);
+                APIElapsedTime = System.currentTimeMillis() - APIStartTime;
+                if (APIElapsedTime < context.getMinimumAPIWaitTime()) {
+                    sleep(context.getMinimumAPIWaitTime() - APIElapsedTime);
                 }
-                lastLevel = curLevel;
+                context.APILock.release();
+
+                long curTotalXP = player.getStats().getExperience();
+                if (curTotalXP > lastExperience) {
+                    if (lastExperience != 0) {
+                        experienceGained += curTotalXP - lastExperience;
+                    }
+                    lastExperience = curTotalXP;
+                }
+                int curLevel = player.getStats().getLevel();
+                if (curLevel > lastLevel) {
+                    PlayerLevelUpRewards rewards = player.acceptLevelUpRewards(curLevel - 1);
+                    if (rewards.getStatus() == PlayerLevelUpRewards.Status.NEW) {
+                        String levelUp = "New level: " + curLevel;
+                        levelUp += convertItemAwards(rewards.getRewards());
+                        PokeMateUI.toast(levelUp, "Level Up", "icons/items/backpack.png");
+                    }
+                    lastLevel = curLevel;
+                }
+
+            } catch (LoginFailedException e) {
+                //e.printStackTrace();
+                System.out.println("[Update] Login Failed, attempting to login again.");
+                Context.Login(context.getHttp());
+            } catch (RemoteServerException e) {
+                System.out.println("[Update] Error - Hit Rate limiter.");
+            } catch (InterruptedException e) {
+                System.out.println("[Navigate] Error - Timed out waiting for API");
+                // e.printStackTrace();
             }
-        } catch (LoginFailedException | RemoteServerException e) {
-            e.printStackTrace();
-            System.out.println("Attempting to Login");
-            Context.Login(context.getHttp());
         }
     }
 	

--- a/src/main/java/dekk/pw/pokemate/tasks/Update.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/Update.java
@@ -16,7 +16,7 @@ import static dekk.pw.pokemate.util.Time.sleep;
 /**
  * Created by TimD on 7/22/2016.
  */
-public class Update extends Task {
+public class Update extends Task implements Runnable {
 
     private static final int[] REQUIRED_EXPERIENCES = new int[]{0, 1000, 3000, 6000, 10000, 15000, 21000, 28000, 36000, 45000, 55000, 65000, 75000,
             85000, 100000, 120000, 140000, 160000, 185000, 210000, 260000, 335000, 435000, 560000, 710000, 900000, 1100000,


### PR DESCRIPTION
1. Rewrote how the taskController operates entirely. Runs each task a single time, each task repeats indefinitely in its own thread.
2. All static sleeps have been removed and each API call is now surrouned by a Mutex lock which is unlocked after completing the call & waiting at least 300ms. PokeMate will never have any issues with the rate limit from now on as long as the API doesn't get rate limited within its own functions.
3. We can now turn on/off features via Interrupts and spawning threads in real time.
4. All tasks run concurrently and in real time rather than running in-order and then waiting 5 seconds. 
5. I had a wild and exciting friday night!
