### PR TITLE
Making drop items more customizable

### DIFF
--- a/config.properties.template
+++ b/config.properties.template
@@ -42,9 +42,8 @@ eggs_incubating=true
 # Enable auto eggs hatching
 eggs_hatching=true
 # Items to drop (remove from this list if you want to keep it, note that inventory management will now be left up to you, as it could be possible to run out of pokeballs)
-drop_item_list=ITEM_POTION,ITEM_SUPER_POTION,ITEM_MAX_POTION,ITEM_HYPER_POTION,ITEM_RAZZ_BERRY,ITEM_REVIVE,ITEM_MAX_REVIVE
-#Minimum amount of each item to save
-minimum_item_amount=10
+# To customize each items min amount add a colon after the item and the min amount to keep, leaving it blank will default it to 0, ie ITEM_POTION is the same as ITEM_POTION:0
+drop_item_list=ITEM_POTION,ITEM_SUPER_POTION,ITEM_MAX_POTION,ITEM_HYPER_POTION,ITEM_RAZZ_BERRY,ITEM_REVIVE,ITEM_MAX_REVIVE,ITEM_POKE_BALL:150
 # Minimum CP for a pokemon to have a pop-up message (All pokemon that are caught will still be logged)
 minimum_cp_for_ui_message=0
 # Prefer IV over CP when transfering? true keeps highest IV, false keeps highest CP

--- a/src/main/java/dekk/pw/pokemate/Config.java
+++ b/src/main/java/dekk/pw/pokemate/Config.java
@@ -7,10 +7,7 @@ import dekk.pw.pokemate.tasks.Navigate;
 import javax.swing.*;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -211,8 +208,10 @@ public class Config {
         return eggsHatching;
     }
 
-    public static List<String> getDroppedItems() {
-        return droppedItems;
+    public static Map<String,Integer> getDroppedItems() {
+        return droppedItems.stream().collect(
+            Collectors.toMap(s -> s.split(":")[0], s -> Integer.parseInt(s.split(":").length == 2 ? s.split(":")[1] : "0"))
+        );
     }
 
     public static int getMinimumCPForMessage() {
@@ -225,9 +224,5 @@ public class Config {
 
     public static void setTransferPrefersIV(boolean transferPrefersIV) {
         Config.transferPrefersIV = transferPrefersIV;
-    }
-
-    public static int getMinItemAmount() {
-        return minItemAmount;
     }
 }

--- a/src/main/java/dekk/pw/pokemate/tasks/DropItems.java
+++ b/src/main/java/dekk/pw/pokemate/tasks/DropItems.java
@@ -25,15 +25,15 @@ class DropItems extends Task implements Runnable {
     @Override
     public void run() {
         try {
-            Config.getDroppedItems().forEach(itemToDrop -> {
+            Config.getDroppedItems().forEach( (itemToDrop, minAmount) -> {
                 ItemId id = ItemId.valueOf(itemToDrop);
                 try {
                     Time.sleepRate();
-                    int count = context.getApi().getInventories().getItemBag().getItem(id).getCount() - Config.getMinItemAmount();
+                    int countToDrop = context.getApi().getInventories().getItemBag().getItem(id).getCount() - minAmount;
                     Time.sleepRate();
-                    if (count > 0) {
-                        context.getApi().getInventories().getItemBag().removeItem(id, count);
-                        String removedItem = "Removed " + StringConverter.titleCase(id.name()) + "(x" + count + ")";
+                    if (countToDrop > 0) {
+                        context.getApi().getInventories().getItemBag().removeItem(id, countToDrop);
+                        String removedItem = "Removed " + StringConverter.titleCase(id.name()) + "(x" + countToDrop + ")";
                         PokeMateUI.toast(removedItem, "Items removed!", "icons/items/" + id.getNumber() + ".png");
                         context.setConsoleString("DropItems", removedItem);
                     }


### PR DESCRIPTION
Making the config more customizable for drop items. Users can stay with current way of inputting the items or add a min to each item. E.g ITEM_POTION:10,ITEM_RAZZ_BERRY:30,ITEM_POKE_BALL:150,ITEM_REVIVE will keep 10 potions, 30 razz berries, 150 pokeballs and drop all revives
